### PR TITLE
typo: script/ should be scripts/

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,7 @@ python setup.py build_ext --inplace
 - Download the pretrained model and unzip the model to **"ROOT_DIR/outputs/hawp"**
 
 ```
-python script/predict.py --config-file config-files/hawp.yaml --img figures/example.png
+python scripts/predict.py --config-file config-files/hawp.yaml --img figures/example.png
 ```
 
 ## Training & Testing


### PR DESCRIPTION
There is a typo in the `readme.md`, it should be:

```
python scripts/predict.py --config-file config-files/hawp.yaml --img figures/example.png
```