### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version="1.0",
     author="nxue",
     description="Holistically-Attracted Wireframe Parsing",
-    packages=find_packages(['hawp']),
+    packages=find_packages(),
     install_requires=[
         "torch", 
         "torchvision",


### PR DESCRIPTION
Fix for pip error
```(base) root@dae8e746a119:/libraries/hawp# pip install -e . Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com Obtaining file:///libraries/hawp
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [12 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/libraries/hawp/setup.py", line 12, in <module>
          packages=find_packages(['hawp']),
        File "/opt/conda/lib/python3.8/site-packages/setuptools/__init__.py", line 62, in find
          return list(
        File "/opt/conda/lib/python3.8/site-packages/setuptools/__init__.py", line 76, in _find_packages_iter
          for root, dirs, files in os.walk(where, followlinks=True):
        File "/opt/conda/lib/python3.8/os.py", line 339, in walk
          top = fspath(top)
      TypeError: expected str, bytes or os.PathLike object, not list
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata. ╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```